### PR TITLE
Add `isPreviewFirst` prop to control order of preview and code sections

### DIFF
--- a/package/src/components/ConditionalWrapper.vue
+++ b/package/src/components/ConditionalWrapper.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+interface Props {
+  isPreviewFirst: boolean;
+}
+
+const props = defineProps<Props>();
+</script>
+
+<template>
+  <div>
+    <template v-if="props.isPreviewFirst">
+      <slot name="preview"></slot>
+      <slot name="code"></slot>
+    </template>
+    <template v-else>
+      <slot name="code"></slot>
+      <slot name="preview"></slot>
+    </template>
+  </div>
+</template>

--- a/package/src/components/VTPCard.vue
+++ b/package/src/components/VTPCard.vue
@@ -2,6 +2,7 @@
 import type { VTPComponentProps } from "../types";
 import { onMounted, nextTick } from "vue";
 import { executeScriptsTick, useHighlighter } from "../shared";
+import ConditionalWrapper from "./ConditionalWrapper.vue";
 
 const props = defineProps<VTPComponentProps>();
 const { highlightedCode, highlightCode } = useHighlighter();
@@ -18,17 +19,22 @@ onMounted(async () => {
 <template>
   <div class="container">
     <h3 v-if="props.title !== ''" v-html="props.title"></h3>
-    <div class="preview">
-      <div class="preview-content" v-html="props.htmlContent"></div>
-    </div>
-
-    <div class="code-content">
-      <div class="language-templ vp-adaptive-theme">
-        <button title="Copy Code" class="copy"></button>
-        <span class="lang">templ</span>
-        <span class="vp-code" v-html="highlightedCode"></span>
-      </div>
-    </div>
+    <ConditionalWrapper :isPreviewFirst="props.isPreviewFirst">
+      <template #preview>
+        <div class="preview">
+          <div class="preview-content" v-html="props.htmlContent"></div>
+        </div>
+      </template>
+      <template #code>
+        <div class="code-content">
+          <div class="language-templ vp-adaptive-theme">
+            <button title="Copy Code" class="copy"></button>
+            <span class="lang">templ</span>
+            <span class="vp-code" v-html="highlightedCode"></span>
+          </div>
+        </div>
+      </template>
+    </ConditionalWrapper>
   </div>
 </template>
 
@@ -49,7 +55,7 @@ onMounted(async () => {
 }
 
 .preview {
-  margin-bottom: 1rem;
+  margin-block: 1rem;
 }
 
 button {

--- a/package/src/plugin/index.ts
+++ b/package/src/plugin/index.ts
@@ -120,6 +120,7 @@ function generateTemplPreviewComponentHtml(
     htmlContent: md.utils.unescapeAll(props.htmlContent),
     buttonStyle: md.utils.escapeHtml(props.buttonStyle),
     themes: props.themes,
+    isPreviewFirst: props.isPreviewFirst,
   };
 
   return `<templ-preview-component v-bind='${JSON.stringify(
@@ -166,6 +167,9 @@ function renderTemplPreview(
   const darkThemeAttr = token.attrs?.find(
     (attr) => attr[0] === "data-theme-dark",
   );
+  const isPreviewFirstAttr = token.attrs?.find(
+    (attr) => attr[0] === "data-preview-first",
+  );
 
   // Retrieving attribute values
   const srcValue = srcAttr[1];
@@ -181,6 +185,9 @@ function renderTemplPreview(
     light: lightThemeValue,
     dark: darkThemeValue,
   };
+  const isPreviewFirstValue = isPreviewFirstAttr
+    ? JSON.parse(isPreviewFirstAttr[1].toLowerCase())
+    : true;
 
   const templFilePath = path.resolve(
     serverRoot,
@@ -237,6 +244,7 @@ function renderTemplPreview(
     htmlContent: md.utils.escapeHtml(htmlContent),
     buttonStyle: buttonStyleValue as ButtonStyle,
     themes: themesValue,
+    isPreviewFirst: isPreviewFirstValue,
   };
 
   return generateTemplPreviewComponentHtml(md, props);

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -60,4 +60,5 @@ export interface VTPComponentProps {
     dark: BundledTheme;
   };
   buttonStyle: ButtonStyle;
+  isPreviewFirst: boolean;
 }

--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -117,7 +117,9 @@ or
 
 ### Component configuration
 
-You can configure the component by passing `data` properties directly to the tag. All `data-*` properties are optionals:
+You can configure the component by passing `data` attributes directly to the tag.
+
+All `data-*` attributes are **optionals**:
 
 ```html
 <templ-demo
@@ -126,6 +128,7 @@ You can configure the component by passing `data` properties directly to the tag
   data-button-variant="brand"
   data-theme-light="vitesse-light"
   data-theme-dark="vitesse-dark"
+  data-preview-first="false"
 />
 ```
 


### PR DESCRIPTION
This PR introduces a new `isPreviewFirst` property to the `VTPComponentProps` interface. 

This property allows the user to set the order of the "preview" and "code" sections. The new property has been implemented in the `VTPCard.vue` component to conditionally render the sections based on its value.